### PR TITLE
CLOUDSDK-206

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Fixed behaviour of --trusted on `extension create` (leaving this flag without trusted|false will create a trusted extension)
 * Added support for hooks in pipelines
 * Fixed crash while activating local pipelines on the remote server
+* Removed resetting the app's start page URL upon `frontend setup`
 
 ## v1.4.1
 * Fix filename of pipeline in boilerplate

--- a/lib/app/frontend/FrontendSetup.js
+++ b/lib/app/frontend/FrontendSetup.js
@@ -38,26 +38,7 @@ class FrontendSetup {
     let answers
     await inquirer.prompt(setupQuestions(await this.getDefaultConfig()))
       .then((inquirerAnswers) => { answers = inquirerAnswers })
-      .then(() => this.registerSettings(answers))
       .then(() => this.save(answers))
-  }
-
-  /**
-   * Registers the settings with the RAPID server.
-   * @param {Object} answers The provided answers.
-   */
-  async registerSettings (answers) {
-    const { confirmed, ip, port } = answers
-    if (!confirmed) throw new Error('Sorry, you canceled the setup! Please try again.')
-
-    const appId = await this.appSettings.getId()
-    const startPageUrl = `http://${ip}:${port}/`
-
-    try {
-      await this.dcClient.setStartPageUrl(appId, startPageUrl)
-    } catch (err) {
-      throw new Error(`Error while setting the start page url in the dev stack: ${err.message}`)
-    }
   }
 
   /**
@@ -65,6 +46,11 @@ class FrontendSetup {
    * @param {Object} answers The provided answers.
    */
   async save (answers) {
+    if (!answers.confirmed) {
+      logger.info('Setup aborted. Re-run in order to finish the process with new settings.')
+      return
+    }
+
     const frontendSettings = this.appSettings.getFrontendSettings()
     await frontendSettings.setIpAddress(answers.ip)
     await frontendSettings.setPort(parseInt(answers.port, 10))


### PR DESCRIPTION
* CLOUDSDK-206 Removed setStartPageUrl() from 'frontend setup' action; removed the now unused registerSettings() method.
* Removed/moved & fixed unit tests.