### PR TITLE
Remove unnecessary os dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,6 @@
     "micromatch": "^3.1.10",
     "morgan": "^1.9.0",
     "neo-async": "^2.5.0",
-    "os": "^0.1.1",
     "os-locale": "^2.1.0",
     "parse-gitignore": "^1.0.1",
     "replace-in-file": "^3.1.0",


### PR DESCRIPTION
`os` is a core module. This package does nothing else than requiring `os`.
See https://unpkg.com/os@0.1.1/index.js