### PR TITLE
Introduced new process.env to enable connecting the RapidDevServer to a custom appId

### DIFF
--- a/lib/app/frontend/FrontendProcess.js
+++ b/lib/app/frontend/FrontendProcess.js
@@ -50,7 +50,7 @@ class FrontendProcess {
     return fork(join(__dirname, './rapidDevServer'), {
       env: {
         ...process.env,
-        appId: process.env.SGCLOUD_RAPID_APP_ID || await this.appSettings.getId(),
+        appId: await this.appSettings.getId(),
         ...(await this.frontendSettings.loadSettings())
       }
     })

--- a/lib/app/frontend/FrontendProcess.js
+++ b/lib/app/frontend/FrontendProcess.js
@@ -50,7 +50,7 @@ class FrontendProcess {
     return fork(join(__dirname, './rapidDevServer'), {
       env: {
         ...process.env,
-        appId: await this.appSettings.getId(),
+        appId: process.env.SGCLOUD_RAPID_APP_ID || await this.appSettings.getId(),
         ...(await this.frontendSettings.loadSettings())
       }
     })

--- a/lib/app/frontend/FrontendSettings.js
+++ b/lib/app/frontend/FrontendSettings.js
@@ -166,7 +166,7 @@ class FrontendSettings {
   }
 
   /**
-   * @param  {FrontendJson} settings
+   * @param  {Internal.FrontendJson} settings
    * @return {Promise<void>}
    */
   async _saveSettings (settings) {
@@ -176,7 +176,7 @@ class FrontendSettings {
   }
 
   /**
-   * @return {Promise<FrontendJson>}
+   * @return {Promise<Internal.FrontendJson>}
    */
   async loadSettings () {
     let settings = {}

--- a/lib/app/frontend/FrontendSetup.js
+++ b/lib/app/frontend/FrontendSetup.js
@@ -18,8 +18,8 @@ const { getLocalIpAdresses } = require('../../utils/utils')
  */
 class FrontendSetup {
   /**
-   * @param {DcHttpClient} dcClient
-   * @param {AppSettings} appSettings
+   * @param {Internal.DcHttpClient} dcClient
+   * @param {Internal.AppSettings} appSettings
    */
   constructor (dcClient, appSettings) {
     this.appSettings = appSettings
@@ -66,7 +66,7 @@ class FrontendSetup {
 
   /**
    * Builds and returns the default configuration.
-   * @return {Object}
+   * @return {Promise<Internal.FrontendJson>}
    */
   async getDefaultConfig () {
     const settings = this.appSettings.getFrontendSettings()

--- a/lib/app/frontend/rapidDevServer/RapidDevServer.js
+++ b/lib/app/frontend/rapidDevServer/RapidDevServer.js
@@ -23,7 +23,7 @@ class RapidDevServer {
   constructor () {
     this.server = null
     this.rapidUrl = process.env.SGCLOUD_RAPID_ADDRESS || 'https://rapid2-sandbox.shopgate.cloud'
-    this.appId = process.env.appId
+    this.appId = process.env.SGCLOUD_RAPID_APP_ID || process.env.appId
     this.rapidApi = new RapidApi(this.rapidUrl, this.appId)
     this.existingServerError = new Error(t('ERROR_CANNOT_INIT_TWICE'))
     this.noIpPortSuppliedError = new Error(t('ERROR_NO_IP_AND_PORT'))

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopgate/platform-sdk",
-  "version": "1.11.1",
+  "version": "1.11.2-beta.1",
   "description": "Shopgate's Platform SDK",
   "main": "index.js",
   "scripts": {

--- a/typings/internal.d.ts
+++ b/typings/internal.d.ts
@@ -28,6 +28,7 @@ declare namespace Internal {
     interface FrontendJson {
         sourceMapsType?: string,
         accessToken?: string,
+        startpageIp?: string,
         remotePort?: number,
         hmrPort?: number,
         apiPort?: number,
@@ -61,7 +62,13 @@ declare namespace Internal {
 
         getSourceMapsType(): Promise<string>,
 
-        setIpAddress(ip: string): Promise<void>,
+        setIpAddress(ip?: string): Promise<void>,
+
+        setStartpageIpAddress(ip?: string): Promise<void>,
+
+        getStartpageIpAddress(): Promise<string>,
+
+        setSourceMapsType(sourceMapsType?: string): Promise<void>,
 
         setPort(port: number): Promise<void>,
 


### PR DESCRIPTION
This pull request introduces a new process.env that can be used to connect the frontend development environment with the backend of a different appId.

Example:
```sh
SGCLOUD_RAPID_APP_ID=shop_12345 sgconnect frontend start
```